### PR TITLE
pymc3 3.11.6 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/deprecat-feedstock/pr2/abbc9a1

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/deprecat-feedstock/pr2/abbc9a1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,39 +1,40 @@
-{% set version = "3.11.4" %}
+{% set name = "pymc3" %}
+{% set version = "3.11.6" %}
 
 package:
-  name: pymc3
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/pymc3/pymc3-{{ version }}.tar.gz
-  sha256: 3b88d1e6c85f7fb8a9b99d6f136ac860672170370ec4146338fdd160c3b3fd3f
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 9e930a1cfd2ee558892b4d92af043696c65a622b64098332687fd75c78f10bce
 
 build:
   number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: true  # [py<37]
-  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python
     - pip
-    - numpy
-    - setuptools
+    - python
     - wheel
+    - setuptools
   run:
     - python
     - arviz >=0.11.0
     - cachetools >=4.2.1
+    - deprecat
     - dill
     - fastprogress >=0.2.0
-    - {{ pin_compatible('numpy') }}
+    - numpy >=1.15.0,<1.22.2
     - pandas >=0.24.0
     - patsy >=0.5.1
-    - scipy >=1.2.0
+    - scipy >=1.7.3,<1.8.0
     - semver >=2.13.0
     - theano-pymc ==1.1.2
-    - typing-extensions >=3.7.4
-
+    # arviz 0.11.2 has requirement typing-extensions<4,>=3.7.4.3, but you have typing-extensions 4.15.0.
+    - typing-extensions >=3.7.4,<4
 
 test:
   imports:
@@ -50,10 +51,12 @@ test:
     - pymc3.tests
     - pymc3.tuning
     - pymc3.variational
-  requires:
-    - pip
   commands:
     - pip check
+    # Tests passed locally. The test run took more than an hour. Skipped.
+    # - pytest --pyargs pymc3.tests
+  requires:
+    - pip
 
 about:
   home: https://github.com/pymc-devs/pymc
@@ -61,8 +64,11 @@ about:
   license_file: LICENSE
   license_family: Apache
   summary: Probabilistic Programming in Python
+  description: |
+    PyMC (formerly PyMC3) is a Python package for Bayesian statistical modeling focusing on advanced Markov chain Monte Carlo (MCMC)
+    and variational inference (VI) algorithms. Its flexibility and extensibility make it applicable to a large suite of problems.
   dev_url: https://github.com/pymc-devs/pymc
-  doc_url: https://docs.pymc.io/en/stable/
+  doc_url: https://docs.pymc.io
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,8 +12,8 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  # theano-pymc ==1.1.2 is already publicly archived, many errors appear because it starts from py312, which removed numpy.distutils, and other problems.
-  skip: true  # [py<37 or py>311]
+  # scipy 1.7.3 availiable only from py38-py310
+  skip: true  # [py<37 or py>310]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<37]
+  # theano-pymc ==1.1.2 is already publicly archived, many errors appear because it starts from py312, which removed numpy.distutils, and other problems.
+  skip: true  # [py<37 or py>311]
 
 requirements:
   host:


### PR DESCRIPTION
pymc3 3.11.6 

**Destination channel:** Defaults

### Links

- [PKG-9407]
- dev_url:        https://github.com/pymc-devs/pymc/tree/v3.11.6
- conda_forge:    https://github.com/conda-forge/pymc3-feedstock
- pypi:           https://pypi.org/project/pymc3/3.11.6
- pypi inspector: https://inspector.pypi.io/project/pymc3/3.11.6

### Explanation of changes:

- new version number


[PKG-9407]: https://anaconda.atlassian.net/browse/PKG-9407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ